### PR TITLE
ccpp_prebuild.py runs to completion

### DIFF
--- a/ufs/ccpp/config/ccpp_prebuild_config.py
+++ b/ufs/ccpp/config/ccpp_prebuild_config.py
@@ -195,11 +195,12 @@ CAPS_SOURCEFILE = '{build_dir}/physics/CCPP_CAPS.sh'
 CAPS_DIR = '{build_dir}/physics'
 
 # Directory where the suite definition files are stored
-SUITES_DIR = '{}/ccpp/suites'.format(fv3_path)
+SUITES_DIR = 'CMEPS/ufs/ccpp/suites'
 
 # Directory where to write static API to
 STATIC_API_DIR = '{build_dir}/physics'
-STATIC_API_SRCFILE = '{build_dir}/physics/CCPP_STATIC_API.sh'
+STATIC_API_CMAKEFILE  = '{build_dir}/physics/CCPP_STATIC_API.cmake'
+STATIC_API_SOURCEFILE = '{build_dir}/physics/CCPP_STATIC_API.sh'
 
 # Directory for writing HTML pages generated from metadata files
 METADATA_HTML_OUTPUT_DIR = '{build_dir}/physics/physics/docs'

--- a/ufs/ccpp/data/GFS_typedefs.F90
+++ b/ufs/ccpp/data/GFS_typedefs.F90
@@ -1,4 +1,8 @@
 module GFS_typedefs
+
+!> \section arg_table_GFS_typedefs
+!! \htmlinclude GFS_typedefs.html
+!!
   use machine,  only: kind_phys
   use physcons, only: con_hvap, con_cp, con_rd, con_eps
   use physcons, only: con_epsm1, con_fvirt 

--- a/ufs/ccpp/data/GFS_typedefs.meta
+++ b/ufs/ccpp/data/GFS_typedefs.meta
@@ -241,7 +241,7 @@
 [ccpp-table-properties]
   name = GFS_typedefs
   type = module
-  relative_path = ../FV3/ccpp/physics/physics
+  relative_path = ../../../../../FV3/ccpp/physics/physics
   dependencies = machine.F,physcons.F90
 
 [ccpp-arg-table]

--- a/ufs/ccpp/data/med_typedefs.F90
+++ b/ufs/ccpp/data/med_typedefs.F90
@@ -3,16 +3,22 @@
 
 module med_type_defs 
 
+!> \section arg_table_med_type_defs
+!! \htmlinclude med_type_defs.html
+!!
+
   use GFS_typedefs, only: GFS_statein_type
   use GFS_typedefs, only: GFS_init_type
   use GFS_typedefs, only: GFS_interstitial_type
   use GFS_typedefs, only: GFS_control_type
   use GFS_typedefs, only: GFS_coupling_type
-  use machine,      only: kind_phys
   use ccpp_api,     only: ccpp_t
 
   implicit none
 
+!! \section arg_table_physics_type
+!! \htmlinclude physics_type.html
+!!
   type physics_type
     type(GFS_init_type)         :: init
     type(GFS_statein_type)      :: statein

--- a/ufs/ccpp/data/med_typedefs.meta
+++ b/ufs/ccpp/data/med_typedefs.meta
@@ -19,34 +19,33 @@
   dimensions = ()
   type = GFS_statein_type
 [Interstitial]
-  standard_name = GFS_interstitial_type
-  long_name = definition of type GFS_interstitial_type
+  standard_name = GFS_interstitial_type_instance
+  long_name = instance of derived type GFS_interstitial_type
   units = DDT
   dimensions = ()
   type = GFS_interstitial_type
 [Model]
-  standard_name = GFS_control_type
-  long_name = definition of type GFS_control_type
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
 [Coupling]
-  standard_name = GFS_coupling_type
-  long_name = definition of type GFS_coupling_type
+  standard_name = GFS_coupling_type_instance
+  long_name = instance of derived type GFS_coupling_type
   units = DDT
   dimensions = ()
   type = GFS_coupling_type
 
 ########################################################################
 [ccpp-table-properties]
-  name = med_typedefs
+  name = med_type_defs
   type = module
   dependencies = GFS_typedefs.F90
-  dependencies = ../FV3/ccpp/physics/physics/machine.F
-  dependencies = ../FV3/ccpp/framework/src/ccpp_api.F90
+  dependencies = ../../../../../FV3/ccpp/framework/src/ccpp_api.F90
 
 [ccpp-arg-table]
-  name = med_typedefs
+  name = med_type_defs
   type = module
 [physics_type]
   standard_name = physics_type

--- a/ufs/ccpp/suites/suite_FV3_sfc_ocean.xml
+++ b/ufs/ccpp/suites/suite_FV3_sfc_ocean.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="FV3_sfc_ocean" version="1">
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>sfc_ocean</scheme>
+    </subcycle>
+  </group>
+</suite>


### PR DESCRIPTION
### Description of changes

A few updates and bugfixes for the ccpp integration in CMEPS. With these, and the following `ccpp_prebuild.py` call, the python script runs to completion:
```
> pwd

> $FV3_PATH/ccpp/framework/scripts/ccpp_prebuild.py --config=CMEPS/ufs/ccpp/config/ccpp_prebuild_config.py   --builddir=/Users/dom.heinzeller/work/ufs-weather-model/ufs-weather-model-ufuk-exchange-grid-20220130/tests/build_fv3_xgrid/CMEPS-interface   --debug --verbose   --suites=FV3_sfc_ocean 2>&1 | tee ccpp_prebuild.log
....
INFO: Added 2 auto-generated caps to /Users/dom.heinzeller/work/ufs-weather-model/ufs-weather-model-ufuk-exchange-grid-20220130/tests/build_fv3_xgrid/CMEPS-interface/physics/CCPP_CAPS.mk and /Users/dom.heinzeller/work/ufs-weather-model/ufs-weather-model-ufuk-exchange-grid-20220130/tests/build_fv3_xgrid/CMEPS-interface/physics/CCPP_CAPS.cmake, /Users/dom.heinzeller/work/ufs-weather-model/ufs-weather-model-ufuk-exchange-grid-20220130/tests/build_fv3_xgrid/CMEPS-interface/physics/CCPP_CAPS.sh
INFO: CCPP prebuild step completed successfully
```

### Specific notes

I added a simple suite `ufs/ccpp/suites/suite_FV3_sfc_ocean.xml` that contains only the `sfc_ocean` scheme.

This PR requires https://github.com/NCAR/ccpp-framework/pull/436 and https://github.com/NCAR/ccpp-framework/issues/435.